### PR TITLE
allows cid-based inline images in html messages

### DIFF
--- a/R/attachment.R
+++ b/R/attachment.R
@@ -2,6 +2,7 @@
 #'
 #' @param msg A message object.
 #' @param path Paths to files.
+#' @param cid a content id.
 #' @return A message object.
 #' @export
 #' @examples
@@ -10,7 +11,7 @@
 #' attachment(msg, "report.xlsx")
 #' attachment(msg, c("visualisations.png", "report.pdf"))
 #' }
-attachment <- function(msg, path){
+attachment <- function(msg, path, cid = round(runif(1,0,10000))){
 
   types <- guess_type(path, empty = NULL)
 
@@ -22,7 +23,7 @@ attachment <- function(msg, path){
     mime <- mime(types[i], "base64", NULL, NULL,
                  name = basename(path[i]),
                  filename = basename(path[i]),
-                 content_transfer_encoding = "base64")
+                 content_transfer_encoding = "base64", cid=cid)
 
     mime$body <- base64encode(body, 76L, "\r\n")
 

--- a/R/mime.R
+++ b/R/mime.R
@@ -26,8 +26,10 @@ format.mime <- function(msg) {
          ifelse(exists("charset") && !is.null(charset), '; charset="{charset}"', ''),
          ifelse(exists("name"), '; name="{name}"', ''),
          '\nContent-Disposition: ',
-         ifelse(grepl("text", content_type), 'inline', 'attachment'),
+         ifelse(grepl("text|image", content_type), 'inline', 'attachment'),
          ifelse(exists("filename"), '; filename="{filename}"', ''),
+         ifelse(exists("cid"), '\nContent-Id: <{cid}>', ''),
+         ifelse(exists("cid"), '\nX-Attachment-Id: {cid}', ''),
          '\nContent-Transfer-Encoding: {encoding}'
        ) %>% paste(collapse = "") %>% glue()
   ) %>%

--- a/man/attachment.Rd
+++ b/man/attachment.Rd
@@ -4,12 +4,14 @@
 \alias{attachment}
 \title{Add attachments to a message object}
 \usage{
-attachment(msg, path)
+attachment(msg, path, cid = round(runif(1, 0, 10000)))
 }
 \arguments{
 \item{msg}{A message object.}
 
 \item{path}{Paths to files.}
+
+\item{cid}{a content id.}
 }
 \value{
 A message object.


### PR DESCRIPTION
As per title, these changes allow an attached image to be included inline in a html message like this:
in R:
email = attachment(email, "myPicture.jpg", cid="3gE3h6re" )

in the HTML:
<img src=3D"cid:3gE3h6re" alt=3D"myPicture.jpg" width=3D"542" height=3D"300">