### PR TITLE
Param to set mime type without guessing.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,5 @@
 ^docs$
 ^pkgdown$
 ^\.httr-oauth$
+^.travis.yml
+^README.Rmd

--- a/R/attachment.R
+++ b/R/attachment.R
@@ -3,7 +3,7 @@
 #' @param msg A message object.
 #' @param path Path to file.
 #' @param cid Content-ID or \code{NA}.
-#' @param mime_type fixed mime type without guessing. Use \link[mime]{mimemap} to set.
+#' @param mime_type fixed mime type without guessing. Use \link[mime]{mimemap} to set. (optional)
 #' @return A message object.
 #' @export
 #' @examples

--- a/R/attachment.R
+++ b/R/attachment.R
@@ -3,6 +3,7 @@
 #' @param msg A message object.
 #' @param path Path to file.
 #' @param cid Content-ID or \code{NA}.
+#' @param mime_type fixed mime type without guessing. Use \link[mime]{mimemap} to set.
 #' @return A message object.
 #' @export
 #' @examples
@@ -12,10 +13,11 @@
 #' attachment(msg, "cat.png")
 #' attachment(msg, "visualisations.png", "visuals")
 #' }
-attachment <- function(msg, path, cid = NA, disposition = NA){
+attachment <- function(msg, path, cid = NA, disposition = NA, mime_type){
   if (length(path) != 1) stop("Must be precisely one attachment.", call. = F)
 
   type <- guess_type(path, empty = NULL)
+  if (!missing(mime_type)) type <- mime_type
 
   if(is.na(disposition)) {
     disposition <- ifelse(

--- a/R/envelope.R
+++ b/R/envelope.R
@@ -17,6 +17,6 @@ envelope <- function() {
 }
 
 #' @export
-print.envelope <- function(msg) {
-  cat(paste0(header(msg), "\n"))
+print.envelope <- function(x, ...) {
+  cat(paste0(header(x), "\n"))
 }

--- a/man/attachment.Rd
+++ b/man/attachment.Rd
@@ -4,14 +4,16 @@
 \alias{attachment}
 \title{Add attachments to a message object}
 \usage{
-attachment(msg, path, cid = NULL)
+attachment(msg, path, cid = NA, disposition = NA, mime_type)
 }
 \arguments{
 \item{msg}{A message object.}
 
-\item{path}{Paths to files.}
+\item{path}{Path to file.}
 
-\item{cid}{A vector of the same length as \code{path} containing either \code{NA} or string values specifying a Content ID for each attachment.}
+\item{cid}{Content-ID or \code{NA}.}
+
+\item{mime_type}{fixed mime type without guessing. Use \link[mime]{mimemap} to set.}
 }
 \value{
 A message object.
@@ -23,6 +25,7 @@ Add attachments to a message object
 \dontrun{
 msg <- envelope()
 attachment(msg, "report.xlsx")
-attachment(msg, c("visualisations.png", "report.pdf"), c("visualizations_01", NA))
+attachment(msg, "cat.png")
+attachment(msg, "visualisations.png", "visuals")
 }
 }

--- a/man/attachment.Rd
+++ b/man/attachment.Rd
@@ -13,7 +13,7 @@ attachment(msg, path, cid = NA, disposition = NA, mime_type)
 
 \item{cid}{Content-ID or \code{NA}.}
 
-\item{mime_type}{fixed mime type without guessing. Use \link[mime]{mimemap} to set.}
+\item{mime_type}{fixed mime type without guessing. Use \link[mime]{mimemap} to set. (optional)}
 }
 \value{
 A message object.

--- a/man/mime.Rd
+++ b/man/mime.Rd
@@ -4,7 +4,8 @@
 \alias{mime}
 \title{Create a MIME (Multipurpose Internet Mail Extensions) object}
 \usage{
-mime(content_type, encoding, format, charset, ...)
+mime(content_type, content_disposition, encoding, format, charset,
+  cid = NA, ...)
 }
 \value{
 A MIME object.


### PR DESCRIPTION
The major change of this pull request is to add the optional `mime_type` to the `attachment` function.

Without this change, you are stuck with `mime::guess_type` function.
