### PR TITLE
Rejection from MS Exchange servers & some argument passing inconsistencies

### DIFF
--- a/R/body.R
+++ b/R/body.R
@@ -21,7 +21,8 @@ text <- function(msg, content, disposition = "inline", charset = "utf-8", encodi
 
   type <- "text/plain"
 
-  body <- mime(type, disposition, encoding, "flowed", charset)
+  #body <- mime(type, disposition, encoding, "flowed", charset)
+  body <- mime(type, disposition, encoding, charset, NA)
   body$body <- content
 
   msg$parts <- c(msg$parts, list(body))
@@ -45,8 +46,9 @@ html <- function(msg, content, disposition = "inline", charset = "utf-8", encodi
   check_message_body(content)
 
   type <- "text/html"
-
-  body <- mime(type, disposition, encoding, NULL, charset)
+  
+  #body <- mime(type, disposition, encoding, NULL, charset)
+  body <- mime(type, disposition, encoding, charset, NA)
   body$body <- qp_encode(content)
 
   msg$parts <- c(msg$parts, list(body))

--- a/R/body.R
+++ b/R/body.R
@@ -19,7 +19,7 @@ check_message_body <- function(content) {
 text <- function(msg, content, disposition = "inline", charset = "utf-8", encoding = "7bit") {
   check_message_body(content)
 
-  type <- "text/plain"
+  type <- "text/plain; charset=\"UTF-8\""
 
   body <- mime(type, disposition, encoding, "flowed", charset)
   body$body <- content

--- a/R/body.R
+++ b/R/body.R
@@ -19,7 +19,7 @@ check_message_body <- function(content) {
 text <- function(msg, content, disposition = "inline", charset = "utf-8", encoding = "7bit") {
   check_message_body(content)
 
-  type <- "text/plain; charset=\"UTF-8\""
+  type <- "text/plain"
 
   body <- mime(type, disposition, encoding, "flowed", charset)
   body$body <- content

--- a/R/envelope.R
+++ b/R/envelope.R
@@ -18,5 +18,5 @@ envelope <- function() {
 
 #' @export
 print.envelope <- function(x, ...) {
-  cat(paste0(header(x), "\n"))
+  cat(paste0(header(x), "\r\n"))
 }

--- a/R/message.R
+++ b/R/message.R
@@ -17,7 +17,7 @@ header <- function(msg) {
   paste(
     msg$header %>% names() %>% sub("_", "-", .) %>% paste0(":") %>% sprintf("%-13s", .),
     msg$header,
-    collapse = "\n"
+    collapse = "\r\n"
   )
 }
 
@@ -37,10 +37,10 @@ message <- function(msg){
 
   if (length(msg$parts)) {
     for (part in msg$parts) {
-      message <- c(message, paste0("\n--", msg$boundary, "\n", format(part)))
+      message <- c(message, paste0("\r\n--", msg$boundary, "\r\n", format(part)))
     }
-    message <- c(message, paste0("\n--", msg$boundary, "--\n"))
+    message <- c(message, paste0("\r\n--", msg$boundary, "--\r\n"))
   }
 
-  do.call(paste0, c(list(message), collapse = "\n"))
+  do.call(paste0, c(list(message), collapse = "\r\n"))
 }

--- a/R/mime.R
+++ b/R/mime.R
@@ -31,7 +31,7 @@ mime <- function(content_type, content_disposition, encoding, charset, cid = NA,
 format.mime <- function(msg) {
   headers <-  with(msg$header, c(
     'Content-Type: {content_type}',
-    ifelse(exists("charset") && !is.null(charset), '; charset="{charset}"', ''),
+    ifelse(exists("charset") && !is.null(charset), '; charset={charset}', ''),
     ifelse(exists("name"), '; name="{name}"', ''),
     '\r\nContent-Disposition: {content_disposition}',
     ifelse(exists("filename"), '; filename="{filename}"', ''),

--- a/R/mime.R
+++ b/R/mime.R
@@ -33,10 +33,10 @@ format.mime <- function(msg) {
     'Content-Type: {content_type}',
     ifelse(exists("charset") && !is.null(charset), '; charset="{charset}"', ''),
     ifelse(exists("name"), '; name="{name}"', ''),
-    '\nContent-Disposition: {content_disposition}',
+    '\r\nContent-Disposition: {content_disposition}',
     ifelse(exists("filename"), '; filename="{filename}"', ''),
-    ifelse(!is.na(cid), '\nContent-Id: <{cid}>\nX-Attachment-Id: {cid}', ''),
-    '\nContent-Transfer-Encoding: {encoding}'
+    ifelse(!is.na(cid), '\r\nContent-Id: <{cid}>\r\nX-Attachment-Id: {cid}', ''),
+    '\r\nContent-Transfer-Encoding: {encoding}'
   ) %>%
     paste(collapse = "") %>%
     glue())


### PR DESCRIPTION
This PR addresses the following issues identified at #32:

1. When sending mail to MS Exchange servers, it bounces back (or ends in spam in the best case) because the mail headers (constructed essentially in ```format.mime()``` and elsewhere) are separated by ```\n``` (or ```<LF>```) instead of ```\r\n``` (or ```<CR><LF>```) violating the standard SMTP protocol. Other servers (GMail, Yahoo) appear to be more lenient on this.

2. Some accidental argument order inconsistencies in ```body.R``` (namely in the ```text()``` and ```html()``` functions caused problems with UTF-8 encoding and possibly attachments. The arguments passed to ```mime()``` were in a different order than expected by ```mime()```.
