### PR TITLE
Use curl::send_mail and accept additional curl options

### DIFF
--- a/man/server.Rd
+++ b/man/server.Rd
@@ -4,7 +4,14 @@
 \alias{server}
 \title{Create a SMTP server object.}
 \usage{
-server(host, port = 25, username = NULL, password = NULL, insecure = FALSE)
+server(
+  host,
+  port = 25,
+  username = NULL,
+  password = NULL,
+  insecure = FALSE,
+  ...
+)
 }
 \arguments{
 \item{host}{DNS name or IP address of the SMTP server.}
@@ -16,6 +23,8 @@ server(host, port = 25, username = NULL, password = NULL, insecure = FALSE)
 \item{password}{Password for SMTP server.}
 
 \item{insecure}{Whether to ignore SSL issues.}
+
+\item{...}{Additional curl options (run curl_options() for a list of supported options)}
 }
 \value{
 A function which is used to send messages to the server.

--- a/tests/testthat/test-server.R
+++ b/tests/testthat/test-server.R
@@ -84,5 +84,5 @@ test_that("sends with verbose output", {
   output <- capture.output(smtp(msg, verbose = TRUE), type = "message") %>%
     paste(collapse = "\n")
 
-  expect_match(output, "^Sending email to")
+  expect_match(output, "250 Message accepted", fixed = TRUE)
 })


### PR DESCRIPTION
Hi,

I needed to pass additional curl options to forbid reusing curl connections to avoid frequent timeouts and could not do it. Had to copy the server function into my own code to modify it and figured out that all this code could be replaced with a single call to curl::send_mail, which does almost exactly the same. 

Please, consider this pull request -  I replace server function with a call to curl::send_mail and add ... parameter to pass additional curl options. I have also modified debugfunction to output debug info directly into stderr(), as there seemed to be no use for storing it into rawConnection.

Thanks,
Oleh Khoma