### PR TITLE
add option to set distinct HELO/EHLO domain

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -41,7 +41,7 @@
 #' # - fill in "bob@gmail.com" for the Sender field and
 #' # - fill in "alice@yahoo.com" for the Recipient field then
 #' # - press the Search button.
-server <- function(host, port = 25, username = NULL, password = NULL, insecure = FALSE, reuse = TRUE,...) {
+server <- function(host, port = 25, username = NULL, password = NULL, insecure = FALSE, reuse = TRUE, helo='',...) {
   sender <- function(msg, verbose = FALSE) {
     debugfunction <- if (verbose) function(type, msg) cat(readBin(msg, character()), file = stderr())
 
@@ -78,7 +78,7 @@ server <- function(host, port = 25, username = NULL, password = NULL, insecure =
 
     protocol <- ifelse(port == 465, "smtps", "smtp")
 
-    smtp_server <- sprintf("%s://%s:%d/", protocol, host, port)
+    smtp_server <- sprintf("%s://%s:%d/%s", protocol, host, port, helo)
     #
     if (verbose) {
       cat("Sending email to ", smtp_server, ".\n", file = stderr(), sep = "")

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -11,6 +11,7 @@ server(
   password = NULL,
   insecure = FALSE,
   reuse = TRUE,
+  helo = '',
   ...
 )
 }
@@ -26,6 +27,8 @@ server(
 \item{insecure}{Whether to ignore SSL issues.}
 
 \item{reuse}{Whether the connection to the SMTP server should be left open for reuse.}
+
+\item{helo}{HELO domain to use in SMTP. Details see https://everything.curl.dev/usingcurl/smtp#the-smtp-url}
 
 \item{...}{Additional curl options. See \code{curl::curl_options()} for a list of supported options.}
 }


### PR DESCRIPTION
some environments need a specific HELO client.domain.fqdn
details see https://everything.curl.dev/usingcurl/smtp#the-smtp-url
i.e. `curl smtp://mail.example.com/client.example.com`