### PR TITLE
don't fail when from is not specified in envelope()

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -112,7 +112,9 @@ server <- function(host, port = 25, username = NULL, password = NULL, insecure =
     # in the email client.
     #
     strip_name <- function(address) {
-      str_replace_all(address, "(^.*<|>$)", "")
+      if (!is.null(address)) {
+        str_replace_all(address, "(^.*<|>$)", "")
+      }
     }
 
     result <- send_mail(


### PR DESCRIPTION
Thanks for this very useful package. Unfortunately, since version 0.4.11 a little program of mine could no longer send emails. I have no figured out the reason and suggest a possible fix for the problem.

When a message is created with `envelope()` without specifying a sender in `from` (i.e., when `from = NULL`), sending the message fails. The reason is that `strip_name()` converts `NULL` to `character(0)` which then later causes the failure. This simple fix ensures that `strip_name(NULL)` returns `NULL`.