### PR TITLE
Strip scalar `"header"` class before `hoist()`ing

### DIFF
--- a/R/parties.R
+++ b/R/parties.R
@@ -21,7 +21,7 @@ parties <- function(msg) {
   map_dfr(c("From", "To", "Cc", "Bcc"), function(type) {
     tibble(
       type,
-      address = msg$headers[type]
+      address = map(msg$headers[type], unclass)
     )
   }) %>%
     hoist(address, "values") %>%


### PR DESCRIPTION
We are planning to release tidyr 1.2.0 in mid January.

This package was flagged in our revdeps. You can reproduce the issue quickly by installing the dev version of tidyr and running:

``` r
library(emayili)

email <- envelope() %>%
  from("Gerald <gerald@gmail.com>") %>%
  to(c("bob@gmail.com", "alice@yahoo.com")) %>%
  cc("Craig     < craig@gmail.com>") %>%
  bcc("  Erin   <erin@yahoo.co.uk    >")

parties(email)
#> Error: Input must be a vector, not a <header> object.
```

The problem is with this `hoist()` call:
https://github.com/datawookie/emayili/blob/6b37fdb9629fe2e076b4ad9f56aded342283432f/R/parties.R#L27

Each element of the `values` column is a `"header"` object. 

Based on this definition of `header()`, it _seems_ like a header is a _scalar_ object, i.e. it isn't one that should be vectorized (similar to, say, a linear model returned from `lm()`).
https://github.com/datawookie/emayili/blob/a73b423a0d0de57ba3d40219ee1cbc12907da37b/R/header.R#L1-L14

Because it is a scalar, our vctrs related tooling (which `hoist()` uses) doesn't know how to work with it (it is designed to work with vectors). Since you seem to want to treat it like a vector list here in this `hoist()` call, I recommend unclassing the header objects before calling `hoist()`. That is what this PR does.

Alternatively, if you _do_ want `"header"` to be treated like a list in all cases, rather than like a scalar object, then if you change this class from `class = "header"` to `class = c("header", "list")` then vctrs will treat it like a list instead. In that case, you could close this PR and make that change instead.
https://github.com/datawookie/emayili/blob/a73b423a0d0de57ba3d40219ee1cbc12907da37b/R/header.R#L12

We'd greatly appreciate if you could apply this fix and send a new version of your package out in early January so we can release tidyr with minimal issues. Thank you!